### PR TITLE
Rebrand color tokens — blue primary + green accent

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,21 +13,23 @@ module.exports = {
     },
     extend: {
       colors: {
-        //
-        primary: '#000CEB',
-        secondary: '#FF6E4D',
-        accent: '#00E2C3',
+        // 2026 rebrand — blue primary + green accent (retires cyan/orange).
+        // Existing token names kept (remapped) so nothing breaks; component
+        // cleanup is per-phase. New ramps below: bg-blue-500, text-green-500…
+        primary: '#0055FF',
+        secondary: '#00FF4F',
+        accent: '#00FF4F',
         // white exists
         lighter: '#F5F5F5',
         light: '#707070',
         black: '#20201E',
-        'accent-2': '#7DE1C3',
-        'secondary-2': '#FB7B3C',
-        'accent-3': '#68DEA44D',
+        'accent-2': '#70FF9B',
+        'secondary-2': '#2BFD6B',
+        'accent-3': '#00FF4F4D',
         // dark
-        'primary-dark': '#000CEB',
-        'secondary-dark': '#FF6E4D',
-        'accent-dark': '#00E2C3',
+        'primary-dark': '#0055FF',
+        'secondary-dark': '#00FF4F',
+        'accent-dark': '#00FF4F',
         'white-dark': '#ffffff',
         // for white bgs in dark
         dark: '#20201E',
@@ -35,9 +37,38 @@ module.exports = {
         'light-dark': '#707070',
         'darker-dark': '#191D1D',
         'black-dark': '#000000',
-        'accent-2-dark': '#7DE1C3',
-        'accent-3-dark': '#68DEA44D',
-        'secondary-2-dark': '#FB7B3C',
+        'accent-2-dark': '#70FF9B',
+        'accent-3-dark': '#00FF4F4D',
+        'secondary-2-dark': '#2BFD6B',
+        // Full ramps from the Figma variable export (public/docs/colors)
+        blue: {
+          50: '#EDF6FF',
+          100: '#D6EAFF',
+          200: '#B5DBFF',
+          300: '#83C6FF',
+          400: '#48A7FF',
+          500: '#1E83FF',
+          600: '#0666FF',
+          700: '#0055FF',
+          800: '#0842C5',
+          900: '#0D3C9B',
+        },
+        green: {
+          50: '#EDFFF1',
+          100: '#D5FFE1',
+          200: '#AEFFC6',
+          300: '#70FF9B',
+          400: '#2BFD6B',
+          500: '#00FF4F',
+          600: '#00C03C',
+          700: '#00962F',
+          800: '#06752A',
+          900: '#076025',
+        },
+      },
+      borderRadius: {
+        '4xl': '2rem',
+        '5xl': '2.5rem',
       },
     },
   },


### PR DESCRIPTION
## Summary

Phase 0 (colors) of the rebrand: maps the Figma variable export into `tailwind.config.js`.

- **`primary` → `#0055FF`** (blue), **`accent`/`secondary` → `#00FF4F`** (green); cyan/orange retired.
- **Non-breaking:** every existing token name is kept (remapped), so the ~140 current usages don't break — per-component cleanup comes in later phases.
- Adds the **full `blue` + `green` ramps** (50→900) as new utilities (`bg-blue-500`, `text-green-500`, …) straight from `public/docs/colors`.
- Adds `rounded-4xl`/`5xl` for the card system.

⚠️ Interim note: some `bg-secondary`/`bg-accent` + white-text combos were tuned for orange/cyan and may need contrast tweaks now that they're bright green — handled during component restyle.

Targets the central `feat/home-redesign-plan` branch per the redesign workflow.

Refs #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)