### PR TITLE
Drop the vertical divider from the About stat cards

### DIFF
--- a/components/home/About.tsx
+++ b/components/home/About.tsx
@@ -35,8 +35,8 @@ const About = () => {
             <div
               key={box.value}
               className={`p-6 md:p-8 lg:p-10 flex flex-col justify-center ${
-                index % 2 === 0 ? 'border-r border-primary' : ''
-              } ${index < 2 ? 'border-b border-primary' : ''}`}
+                index < 2 ? 'border-b border-primary' : ''
+              }`}
             >
               <div className="text-primary text-3xl md:text-5xl lg:text-6xl font-display mb-2">
                 {box.value}


### PR DESCRIPTION
The design splits the 2x2 stat grid with a **single horizontal hairline**. The vertical border between the columns was mine, not the design's — I added it when building the grid and it went unnoticed in #139.

Spotted while working through the flutter frames, where the same grid appears and makes the difference obvious. The matching fix on the flutter side is in flutterconKE#38.

One line: the `border-r` comes off, `border-b` on the top row stays.