### PR TITLE
feat: update content and branding for 2026 conference, including new statistics and descriptions

### DIFF
--- a/components/home/About.tsx
+++ b/components/home/About.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 const statsBoxes = [
   { value: '7TH', label: 'DROIDCON EDITION' },
-  { value: '3RD', label: 'FLUTTER EDITION' },
-  { value: '200+', label: 'SESSIONS' },
-  { value: '3000+', label: 'ATTENDEES' },
+  { value: '3RD', label: 'FLUTTERCON EDITION' },
+  { value: '200+', label: 'Sessions Delivered' },
+  { value: '3,000+', label: 'Attendees Since 2018' },
 ]
 
 const About = () => {

--- a/components/home/Banner.tsx
+++ b/components/home/Banner.tsx
@@ -178,7 +178,7 @@ export const Banner = () => {
 
           {/* Subtitle */}
           <p className="text-gray-700 dark:text-accent-dark text-lg md:text-xl lg:text-2xl font-medium max-w-3xl mb-8 leading-snug mx-auto text-center">
-            Africa&apos;s largest Mobile developer conference.
+            Sub-Saharan Africa&apos;s premier mobile development conference.
             <br />2 Days 1 Ticket.
           </p>
 
@@ -254,7 +254,7 @@ export const Banner = () => {
               CONFERENCES
             </p>
             <p className="font-bold text-sm md:text-base text-black dark:text-white uppercase">
-              DROIDCON &middot; FLUTTER
+              DROIDCON &middot; FLUTTERCON
             </p>
           </div>
         </div>

--- a/components/home/ConfHighlights.tsx
+++ b/components/home/ConfHighlights.tsx
@@ -5,7 +5,7 @@ const highlights = [
   {
     id: 'beyond-the-sessions',
     title: ['Beyond the', 'Sessions'],
-    body: 'Hands-on labs, engineering leader panels, and real dev talk. Master Agentic AI, level up your security game, and fast-track your career at the Fluttercon Kenya joint track.',
+    body: 'Hands-on labs, engineering leader panels, and real dev talk. Master Agentic AI, level up your security game, and fast-track your career at the Unconference Track.',
     image: '/images/new-design/revised/beyond-sessions.png',
     imageAlt: 'Two toy robots shaking hands',
     cardClass: 'bg-primary',

--- a/components/home/Marquee.tsx
+++ b/components/home/Marquee.tsx
@@ -4,7 +4,7 @@ const marqueeItems: string[] = [
   'DroidconKE 2026',
   '05-06 Nov 2026',
   'Nairobi, Kenya',
-  'The largest Mobile Event in Africa',
+  "Sub-Saharan Africa's premier mobile development conference",
 ]
 
 const MarqueeContent = () => (

--- a/components/layouts/default.tsx
+++ b/components/layouts/default.tsx
@@ -15,7 +15,9 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
       <Head>
-        <title>The Largest Mobile Developers&apos; Conference in Africa</title>
+        <title>
+          Sub-Saharan Africa&apos;s premier mobile development conference
+        </title>
       </Head>
       <ThemeProvider>
         <div className="w-full min-h-screen bg-white dark:bg-dark">

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,7 +1,7 @@
 import { Html, Head, Main, NextScript } from 'next/document'
 
 const Document = () => {
-  const title = `The Largest Mobile Developers' Conference in Africa`
+  const title = `Sub-Saharan Africa's premier mobile development conference`
   return (
     <Html lang="en">
       <Head>

--- a/pages/sponsors.tsx
+++ b/pages/sponsors.tsx
@@ -66,12 +66,28 @@ export default function SponsorsPage({ sponsors }: { sponsors: Sponsor[] }) {
                 </div>
                 <div className="w-full md:w-8/12">
                   <p className="text-white text-sm md:text-base leading-relaxed">
-                    The event targets students, professional software developers
-                    who work in mid to large sized organizations and who develop
-                    systems of all sizes for enterprise companies. The event
-                    aims to attract attendees across industries such as
-                    financial services, media houses, telco’s etc.
+                    The event attracts professional software developers who work
+                    in mid to large sized organizations and who develop systems
+                    of all sizes for enterprise companies. The event aims to
+                    attract attendees across industries such as financial
+                    services, media houses, telco’s etc.
                   </p>
+                  <div className="mt-6 grid grid-cols-3 gap-x-6 gap-y-6">
+                    {[
+                      { value: '80.6%', label: 'Professional Developers' },
+                      { value: '4.6/5', label: 'Satisfaction Score' },
+                      { value: '9.3/10', label: 'Net Promoter Score' },
+                    ].map((stat) => (
+                      <div key={stat.label}>
+                        <p className="font-display leading-none text-3xl md:text-4xl text-white dark:text-white">
+                          {stat.value}
+                        </p>
+                        <p className="mt-1.5 text-[11px] md:text-xs font-semibold text-white dark:text-white">
+                          {stat.label}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
               <div className="rounded-3xl md:rounded-4xl bg-white border-[3px] md:border-4 border-accent px-7 py-6 md:px-[3.75rem] md:py-12 -mb-20 md:-mb-28">
@@ -83,11 +99,11 @@ export default function SponsorsPage({ sponsors }: { sponsors: Sponsor[] }) {
                   </div>
                   <div className="w-full md:w-8/12 grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-14">
                     {[
-                      { value: '700+', label: '2026 Attendees Target' },
-                      { value: '80+', label: 'Sessions' },
+                      { value: '3000+', label: 'Attendees Since 2018' },
+                      { value: '60+', label: 'Sessions' },
                       { value: '3', label: 'Tracks' },
-                      { value: '5000+', label: 'Newsletter Reach' },
-                      { value: '3200+', label: 'Twitter Followers' },
+                      { value: '14000+', label: 'Newsletter Reach' },
+                      { value: '6000+', label: 'Twitter Followers' },
                       { value: '2', label: 'Day Event' },
                     ].map((stat) => (
                       <div key={stat.label}>
@@ -119,7 +135,7 @@ export default function SponsorsPage({ sponsors }: { sponsors: Sponsor[] }) {
               sponsor dcke26
             </div>
             <h2 className="font-display capitalize text-3xl md:text-5xl text-primary dark:text-primary">
-              Sponsor droidcon26
+              Sponsor droidconke26
             </h2>
             <div
               className="h-2 w-full max-w-xs md:max-w-md bg-primary mt-4"
@@ -134,7 +150,7 @@ export default function SponsorsPage({ sponsors }: { sponsors: Sponsor[] }) {
               To earn a spot here/Meet our partners By sponsoring
             </h6>
             <h3 className="font-display capitalize text-2xl md:text-3xl text-primary dark:text-primary mt-10 md:mt-12">
-              <span>To Sponsor</span> Droidcoke 2026 Contacts us at?
+              <span>To Sponsor</span> droidconke 2026, contact us at:
             </h3>
             <Link
               href="mailto:sponsor@droidcon.co.ke?Subject=Sponsor droidconKe"


### PR DESCRIPTION
This pull request updates event branding and statistics across the site to emphasize "Sub-Saharan Africa's premier mobile development conference" and to reflect the latest attendee and session data. It also improves clarity and consistency in event naming (e.g., "FLUTTERCON" instead of "FLUTTER"), updates conference highlights, and adds new sponsor-related statistics.

**Branding and Messaging Updates:**
- Updated all main titles, subtitles, and meta tags to use "Sub-Saharan Africa's premier mobile development conference" instead of "The Largest Mobile Developers' Conference in Africa" for consistency and improved positioning. [[1]](diffhunk://#diff-e90331129353b1c517cafd9f9c495c2b2ecd87979d724696671d287e46113007L18-R20) [[2]](diffhunk://#diff-b1a4d3316040332c1890ee43ea9c898cbf19b7ea45115210c42e3b42817a279eL7-R7) [[3]](diffhunk://#diff-d46b84d196e1a9fca582550b5793ae90fd6dba89bd8f2e3d8e86438b82847fe0L181-R181) [[4]](diffhunk://#diff-69a97c4e30118f9e9000fedfd8f59f43b4353021528208a4ff946e503c0b3dacL4-R4)

**Event Naming Consistency:**
- Changed all references from "FLUTTER" to "FLUTTERCON" in stats boxes and banners for accuracy. [[1]](diffhunk://#diff-6e327950339dd18e7e565c5410a8790df2f2bdf98cb5601d4d8f44f016207184L5-R7) [[2]](diffhunk://#diff-d46b84d196e1a9fca582550b5793ae90fd6dba89bd8f2e3d8e86438b82847fe0L257-R257)
- Corrected sponsor section headings and contact information to consistently use "droidconke" and proper capitalization. [[1]](diffhunk://#diff-1883451800ea29d92c99294dc0dd8770650b463dccb881e236698a19218bbae9L122-R138) [[2]](diffhunk://#diff-1883451800ea29d92c99294dc0dd8770650b463dccb881e236698a19218bbae9L137-R153)

**Statistics and Data Updates:**
- Updated stats boxes and sponsor page metrics to reflect current data: e.g., "3,000+ Attendees Since 2018", "Sessions Delivered", "14000+ Newsletter Reach", "6000+ Twitter Followers", and "60+ Sessions". [[1]](diffhunk://#diff-6e327950339dd18e7e565c5410a8790df2f2bdf98cb5601d4d8f44f016207184L5-R7) [[2]](diffhunk://#diff-1883451800ea29d92c99294dc0dd8770650b463dccb881e236698a19218bbae9L86-R106)
- Added new sponsor section statistics: "80.6% Professional Developers", "4.6/5 Satisfaction Score", and "9.3/10 Net Promoter Score".

**Content Improvements:**
- Reworded event description to clarify the audience, focusing on professional developers and removing the mention of students.
- Updated conference highlights to refer to the "Unconference Track" instead of "Fluttercon Kenya joint track" for accuracy.