### PR TITLE
feat: update wording for statistics and social media reach on sponsor…

### DIFF
--- a/pages/sponsors.tsx
+++ b/pages/sponsors.tsx
@@ -72,22 +72,6 @@ export default function SponsorsPage({ sponsors }: { sponsors: Sponsor[] }) {
                     attract attendees across industries such as financial
                     services, media houses, telco’s etc.
                   </p>
-                  <div className="mt-6 grid grid-cols-3 gap-x-6 gap-y-6">
-                    {[
-                      { value: '80.6%', label: 'Professional Developers' },
-                      { value: '4.6/5', label: 'Satisfaction Score' },
-                      { value: '9.3/10', label: 'Net Promoter Score' },
-                    ].map((stat) => (
-                      <div key={stat.label}>
-                        <p className="font-display leading-none text-3xl md:text-4xl text-white dark:text-white">
-                          {stat.value}
-                        </p>
-                        <p className="mt-1.5 text-[11px] md:text-xs font-semibold text-white dark:text-white">
-                          {stat.label}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
                 </div>
               </div>
               <div className="rounded-3xl md:rounded-4xl bg-white border-[3px] md:border-4 border-accent px-7 py-6 md:px-[3.75rem] md:py-12 -mb-20 md:-mb-28">
@@ -103,7 +87,7 @@ export default function SponsorsPage({ sponsors }: { sponsors: Sponsor[] }) {
                       { value: '60+', label: 'Sessions' },
                       { value: '3', label: 'Tracks' },
                       { value: '14000+', label: 'Newsletter Reach' },
-                      { value: '6000+', label: 'Twitter Followers' },
+                      { value: '6000+', label: 'Social Media Reach' },
                       { value: '2', label: 'Day Event' },
                     ].map((stat) => (
                       <div key={stat.label}>


### PR DESCRIPTION
This pull request makes minor updates to the sponsors page, mainly focusing on the presentation of event statistics.

Content and presentation updates:

* Removed the three-column grid displaying "Professional Developers", "Satisfaction Score", and "Net Promoter Score" statistics from the sponsors page.
* Updated the label "Twitter Followers" to "Social Media Reach" in the event statistics section for improved clarity and inclusivity.